### PR TITLE
print error when no directories are found

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ is found, it will be rendered with [bat](https://github.com/sharkdp/bat) by defa
 if `bat` is installed, otherwise it will be rendered with `cat`. You can force using
 or not using `bat` with the `preview_with_bat` option. You can default to always
 using the fallback instead of rendering a file by setting an empty list of globbing
-patterns, like: `preview_files:`.
+patterns, like: `preview_files: []`.
 
 If no matching preview files are found, the directory listing is used as the preview. By
 default, directory contents are listed using [exa](https://github.com/ogham/exa) by default

--- a/src/commands/find.rs
+++ b/src/commands/find.rs
@@ -6,6 +6,9 @@ use crate::{
     settings::Settings,
 };
 
+// the global settings object
+// gets these merged into it
+// at runtime
 #[derive(StructOpt)]
 pub struct Cmd {
     #[structopt(long)]
@@ -22,6 +25,21 @@ impl Cmd {
     pub fn run(&self) -> Result<Option<String>, GetDirsError> {
         Settings::merge_find_args(self);
         let dirs = get_dirs()?;
+        if dirs.is_empty() {
+            let search_dirs = Settings::get_readonly().search_dirs;
+            let search_dirs_str = if search_dirs.is_empty() {
+                String::from("[Empty list]")
+            } else {
+                Settings::get_readonly()
+                    .search_dirs
+                    .iter()
+                    .map(|dir_str| format!("- {}", dir_str))
+                    .collect::<Vec<String>>()
+                    .join("\n")
+            };
+            eprintln!("No directories found under configured `search_dirs`, do you need to customize `search_dirs` in `~/.config/ctrlg/config.yml`?\nCurrent `search_dirs` value is configured as:\n{}\n\n", search_dirs_str);
+            return Ok(None);
+        }
         let selected = find(&dirs);
         Ok(selected)
     }


### PR DESCRIPTION
Fixes #13 

There was some confusion around configuring the tool. So now, if no directories are found, it prints an error and asks if you need to set some configuration.