### PR TITLE
Ability to customize color scheme

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,3 +22,6 @@ jobs:
       with:
         command: build
         args: --release
+    - uses: actions-rs/cargo@v1
+      with:
+        command: test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
       - name: Cargo Publish
         env:
           CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,3 @@ publish:
 	@if [ "$(CARGO_TOKEN)" = "" ]; then echo "CARGO_TOKEN variable not set"; exit 1; fi
 	cargo login $(CARGO_TOKEN)
 	cargo publish
-
-.PHONY: clean
-clean:
-	@cargo clean
-
-.PHONY: test
-test:
-	cargo test

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,7 @@ publish:
 .PHONY: clean
 clean:
 	@cargo clean
+
+.PHONY: test
+test:
+	cargo test

--- a/README.md
+++ b/README.md
@@ -90,6 +90,16 @@ show_git_branch: true
 # character to render between the directory name and git branch name
 # you can change this to a Nerd Font symbol if you like
 git_branch_separator: "■"
+# customize color scheme
+# see section on "customization" below for more details
+colors:
+  # directory name color
+  dir_name: "cyan"
+  # git branch color
+  git_branch: "red"
+  # name of theme to use for `bat`
+  # see: https://github.com/sharkdp/bat#highlighting-theme
+  bat_theme: "ansi"
 ```
 
 Any configuration values can be overridden by passing them as arguments to the CLI.
@@ -111,3 +121,23 @@ If no matching preview files are found, the directory listing is used as the pre
 default, directory contents are listed using [exa](https://github.com/ogham/exa) by default
 if `exa` is installed, otherwise contents are listed using `ls`. You can force using or not
 using `exa` as the fallback preview using the `preview_fallback_exa` option.
+
+### Customization
+
+Colors in the config file may be specified as a named color,
+a single integer corresponding to [xterm-256 color codes](https://upload.wikimedia.org/wikipedia/commons/1/15/Xterm_256color_chart.svg),
+or an RGB triple of integers (e.g. `255,255,255`). If an invalid color is specified
+(e.g. if you use decimals instead of integers, or an invalid named color), it will default to
+white. For `xterm-256` or RGB colors to work, it must be supported by your terminal emulator.
+I recommend [Kitty](https://sw.kovidgoyal.net/kitty/).
+
+Named colors are the following:
+
+- `"black"`
+- `"red"`
+- `"green"`
+- `"yellow"`
+- `"blue"`
+- `"purple"`
+- `"cyan"`
+- `"white`

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -20,7 +20,7 @@ pub fn parse_rgb_triple(input: &str) -> Option<(u8, u8, u8)> {
     None
 }
 
-pub fn parse_color(input: &String) -> Color {
+pub fn parse_color(input: &str) -> Color {
     match input.to_lowercase().as_str() {
         "black" => Color::Black,
         "red" => Color::Red,

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -1,0 +1,46 @@
+use ansi_term::Color;
+use std::num::ParseIntError;
+
+pub fn parse_rgb_triple(input: &String) -> Option<(u8, u8, u8)> {
+    let values = input
+        .split(',')
+        .map(|value| value.trim())
+        .collect::<Vec<&str>>();
+    if values.len() != 3 {
+        return None;
+    }
+
+    let values: Result<Vec<u8>, ParseIntError> =
+        values.iter().map(|value| value.parse::<u8>()).collect();
+
+    if let Ok(values) = values {
+        return Some((values[0], values[1], values[2]));
+    }
+
+    None
+}
+
+pub fn parse_color(input: &String, default_color: Color) -> Color {
+    match input.to_lowercase().as_str() {
+        "black" => Color::Black,
+        "red" => Color::Red,
+        "green" => Color::Green,
+        "yellow" => Color::Yellow,
+        "blue" => Color::Blue,
+        "purple" => Color::Purple,
+        "cyan" => Color::Cyan,
+        "white" => Color::White,
+        _ => {
+            // check for an integer-specified xterm-256 color
+            // see: https://upload.wikimedia.org/wikipedia/commons/1/15/Xterm_256color_chart.svg
+            let is_xterm_256_color = input.parse::<u8>();
+            if let Ok(color_int) = is_xterm_256_color {
+                Color::Fixed(color_int)
+            } else if let Some(rgb_triple) = parse_rgb_triple(input) {
+                Color::RGB(rgb_triple.0, rgb_triple.1, rgb_triple.2)
+            } else {
+                default_color
+            }
+        }
+    }
+}

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -45,3 +45,38 @@ pub fn parse_color(input: &str) -> Color {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use ansi_term::Color;
+
+    macro_rules! color_test {
+        ($($name:ident: $value:expr,)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let (input, expected) = $value;
+                    let output = parse_color(input);
+                    assert_eq!(expected, output);
+                }
+            )*
+        }
+    }
+
+    color_test! {
+        black: ("black", Color::Black),
+        red: ("red", Color::Red),
+        green: ("green", Color::Green),
+        yellow: ("yellow", Color::Yellow),
+        blue: ("blue", Color::Blue),
+        purple: ("purple", Color::Purple),
+        cyan: ("cyan", Color::Cyan),
+        white: ("white", Color::White),
+        invalid_named_color: ("invalid named color", Color::White),
+        fixed_color: ("255", Color::Fixed(255)),
+        rgb: ("255,255,255", Color::RGB(255, 255, 255)),
+        decimal_fixed: ("17.25", Color::White), // decimal fixed colors are not valid
+        decimal_rgb: ("17.25, 17.25, 17.25", Color::White), // decimal RGB colors are not valid
+    }
+}

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -1,7 +1,7 @@
 use ansi_term::Color;
 use std::num::ParseIntError;
 
-pub fn parse_rgb_triple(input: &String) -> Option<(u8, u8, u8)> {
+pub fn parse_rgb_triple(input: &str) -> Option<(u8, u8, u8)> {
     let values = input
         .split(',')
         .map(|value| value.trim())
@@ -20,7 +20,7 @@ pub fn parse_rgb_triple(input: &String) -> Option<(u8, u8, u8)> {
     None
 }
 
-pub fn parse_color(input: &String, default_color: Color) -> Color {
+pub fn parse_color(input: &String) -> Color {
     match input.to_lowercase().as_str() {
         "black" => Color::Black,
         "red" => Color::Red,
@@ -30,7 +30,7 @@ pub fn parse_color(input: &String, default_color: Color) -> Color {
         "purple" => Color::Purple,
         "cyan" => Color::Cyan,
         "white" => Color::White,
-        _ => {
+        input => {
             // check for an integer-specified xterm-256 color
             // see: https://upload.wikimedia.org/wikipedia/commons/1/15/Xterm_256color_chart.svg
             let is_xterm_256_color = input.parse::<u8>();
@@ -39,7 +39,8 @@ pub fn parse_color(input: &String, default_color: Color) -> Color {
             } else if let Some(rgb_triple) = parse_rgb_triple(input) {
                 Color::RGB(rgb_triple.0, rgb_triple.1, rgb_triple.2)
             } else {
-                default_color
+                eprintln!("Invalid color definition found in config file: '{}'", input);
+                Color::White
             }
         }
     }

--- a/src/dir_item.rs
+++ b/src/dir_item.rs
@@ -1,9 +1,4 @@
-use crate::{
-    colors::parse_color,
-    git_meta,
-    settings::{ColorSettings, Settings},
-};
-use ansi_term::Color;
+use crate::{colors::parse_color, git_meta, settings::Settings};
 use glob::glob;
 use std::{
     fmt::Display,

--- a/src/dir_item.rs
+++ b/src/dir_item.rs
@@ -1,5 +1,9 @@
-use crate::{git_meta, settings::Settings};
-use ansi_term::Color::{Cyan, Red};
+use crate::{
+    colors::parse_color,
+    git_meta,
+    settings::{ColorSettings, Settings},
+};
+use ansi_term::Color;
 use glob::glob;
 use std::{
     fmt::Display,
@@ -76,11 +80,14 @@ fn get_display(path: &Path) -> Result<String, DirItemError> {
 
     let branch = git_meta::get_current_branch(path)?;
     if let Some(branch) = branch {
+        let settings = Settings::get_readonly();
+        let color_settings = settings.colors.unwrap_or_else(|| ColorSettings::default());
         display = format!(
             "{}  {} {}",
-            Cyan.paint(display),
-            Red.paint(Settings::get_readonly().git_branch_separator),
-            Red.paint(branch)
+            parse_color(&color_settings.dir_name, Color::Cyan).paint(display),
+            parse_color(&color_settings.git_branch, Color::Red)
+                .paint(settings.git_branch_separator),
+            parse_color(&color_settings.git_branch, Color::Red).paint(branch),
         );
     }
 

--- a/src/dir_item.rs
+++ b/src/dir_item.rs
@@ -84,9 +84,11 @@ fn get_display(path: &Path) -> Result<String, DirItemError> {
         let color_settings = settings.colors;
         display = format!(
             "{}  {} {}",
-            parse_color(&color_settings.dir_name).paint(display),
-            parse_color(&color_settings.git_branch).paint(settings.git_branch_separator),
-            parse_color(&color_settings.git_branch).paint(branch),
+            parse_color(&color_settings.dir_name).bold().paint(display),
+            parse_color(&color_settings.git_branch)
+                .bold()
+                .paint(settings.git_branch_separator),
+            parse_color(&color_settings.git_branch).bold().paint(branch),
         );
     }
 

--- a/src/dir_item.rs
+++ b/src/dir_item.rs
@@ -81,13 +81,12 @@ fn get_display(path: &Path) -> Result<String, DirItemError> {
     let branch = git_meta::get_current_branch(path)?;
     if let Some(branch) = branch {
         let settings = Settings::get_readonly();
-        let color_settings = settings.colors.unwrap_or_else(|| ColorSettings::default());
+        let color_settings = settings.colors;
         display = format!(
             "{}  {} {}",
-            parse_color(&color_settings.dir_name, Color::Cyan).paint(display),
-            parse_color(&color_settings.git_branch, Color::Red)
-                .paint(settings.git_branch_separator),
-            parse_color(&color_settings.git_branch, Color::Red).paint(branch),
+            parse_color(&color_settings.dir_name).paint(display),
+            parse_color(&color_settings.git_branch).paint(settings.git_branch_separator),
+            parse_color(&color_settings.git_branch).paint(branch),
         );
     }
 

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -1,6 +1,6 @@
 use crate::command_strs;
 use crate::dir_item::DirItem;
-use crate::settings::{Settings, SETTINGS};
+use crate::settings::Settings;
 use skim::prelude::*;
 use skim::{prelude::unbounded, SkimItem, SkimItemReceiver, SkimItemSender};
 use std::{borrow::Cow, sync::Arc};
@@ -15,8 +15,9 @@ impl SkimItem for DirItem {
     }
 
     fn preview(&self, _context: PreviewContext) -> ItemPreview {
+        let settings = Settings::get_readonly();
         if self.readme.is_none() {
-            if Settings::get_readonly().preview_fallback_exa {
+            if settings.preview_fallback_exa {
                 return ItemPreview::Command(format!(
                     "{} \"{}\"",
                     command_strs::EXA.join(" "),
@@ -32,10 +33,13 @@ impl SkimItem for DirItem {
         }
 
         let readme_path = self.readme.as_ref().unwrap();
-        if SETTINGS.lock().unwrap().preview_with_bat {
+        if settings.preview_with_bat {
+            let mut bat_args = command_strs::BAT.to_vec();
+            let bat_theme_arg = format!("--theme={}", settings.colors.bat_theme);
+            bat_args.push(bat_theme_arg.as_str());
             ItemPreview::Command(format!(
                 "{} \"{}\"",
-                command_strs::BAT.join(" "),
+                bat_args.join(" "),
                 readme_path.to_str().unwrap().to_string()
             ))
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use commands::CtrlgCommand;
 use std::error::Error;
 use structopt::{clap::AppSettings, StructOpt};
 
+mod colors;
 mod command_strs;
 mod commands;
 mod dir_item;
@@ -19,7 +20,11 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
     author = "Mat Jones <mat@mjones.network>",
     version = VERSION,
     about = "Press ctrl+g to search and jump to any directory",
-    global_settings(&[AppSettings::ColoredHelp, AppSettings::DeriveDisplayOrder])
+    global_settings(&[
+        AppSettings::UnifiedHelpMessage,
+        AppSettings::ColoredHelp,
+        AppSettings::DeriveDisplayOrder
+    ])
 )]
 struct Ctrlg {
     #[structopt(subcommand)]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -6,6 +6,13 @@ use std::{env, fs, path::PathBuf, sync::Mutex};
 
 const CONFIG_FILE_NAMES: [&str; 2] = ["config.yml", "config.yaml"];
 
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct ColorSettings {
+    pub dir_name: String,
+    pub git_branch: String,
+    pub bat_theme: String,
+}
+
 #[derive(Debug, Deserialize, Clone)]
 pub struct Settings {
     pub search_dirs: Vec<String>,
@@ -15,6 +22,7 @@ pub struct Settings {
     pub preview_fallback_exa: bool,
     pub show_git_branch: bool,
     pub git_branch_separator: String,
+    pub colors: Option<ColorSettings>,
 }
 
 fn is_program_in_path(program: &str) -> bool {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -49,7 +49,7 @@ impl Settings {
         s.set_default("show_git_branch", true)?;
         s.set_default("git_branch_separator", "■")?;
         s.set_default("colors.dir_name", "cyan")?;
-        s.set_default("colors.git_branch", "red")?;
+        s.set_default("colors.git_branch", "247,78,39")?; // git brand orange color
         s.set_default("colors.bat_theme", "ansi")?;
 
         let home = home_dir();

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -6,7 +6,7 @@ use std::{env, fs, path::PathBuf, sync::Mutex};
 
 const CONFIG_FILE_NAMES: [&str; 2] = ["config.yml", "config.yaml"];
 
-#[derive(Debug, Deserialize, Clone, Default)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct ColorSettings {
     pub dir_name: String,
     pub git_branch: String,
@@ -22,7 +22,7 @@ pub struct Settings {
     pub preview_fallback_exa: bool,
     pub show_git_branch: bool,
     pub git_branch_separator: String,
-    pub colors: Option<ColorSettings>,
+    pub colors: ColorSettings,
 }
 
 fn is_program_in_path(program: &str) -> bool {
@@ -48,6 +48,9 @@ impl Settings {
         s.set_default("preview_fallback_exa", is_program_in_path("exa"))?;
         s.set_default("show_git_branch", true)?;
         s.set_default("git_branch_separator", "■")?;
+        s.set_default("colors.dir_name", "cyan")?;
+        s.set_default("colors.git_branch", "red")?;
+        s.set_default("colors.bat_theme", "")?;
 
         let home = home_dir();
         if home.is_none() {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -50,7 +50,7 @@ impl Settings {
         s.set_default("git_branch_separator", "■")?;
         s.set_default("colors.dir_name", "cyan")?;
         s.set_default("colors.git_branch", "red")?;
-        s.set_default("colors.bat_theme", "")?;
+        s.set_default("colors.bat_theme", "ansi")?;
 
         let home = home_dir();
         if home.is_none() {
@@ -107,5 +107,12 @@ impl Settings {
 }
 
 lazy_static! {
-    pub static ref SETTINGS: Mutex<Settings> = Mutex::from(Settings::new().unwrap());
+    pub static ref SETTINGS: Mutex<Settings> = {
+        let settings = Settings::new();
+        if let Err(e) = settings {
+            panic!("Failed to parse yml from configuration file: {}", e);
+        }
+
+        Mutex::from(settings.unwrap())
+    };
 }


### PR DESCRIPTION
Fixes: #23 

Adds a new `colors` key to the configuration. You can set `colors.dir_name`, `colors.branch_name`, and `colors.bat_theme`.