### PR TITLE
migrate from structopt to clap 3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,9 +111,41 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim 0.8.0",
- "textwrap",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17bf219fcd37199b9a29e00ba65dfb8cd5b2688b7297ec14ff829c40ac50ca9"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim 0.10.0",
+ "termcolor",
+ "terminal_size",
+ "textwrap 0.14.2",
+ "unicase",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b9752c030a14235a0bd5ef3ad60a1dcac8468c30921327fc8af36b20c790b9"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -125,7 +157,7 @@ dependencies = [
  "lazy_static",
  "nom",
  "rust-ini",
- "serde 1.0.132",
+ "serde 1.0.133",
  "serde-hjson",
  "serde_json",
  "toml",
@@ -134,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "const_fn"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92cfa0fd5690b3cf8c1ef2cabbd9b7ef22fa53cf5e1f92b05103f6d5d1cf6e7"
+checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
 
 [[package]]
 name = "crossbeam"
@@ -232,15 +264,15 @@ name = "ctrlg"
 version = "0.3.5"
 dependencies = [
  "ansi_term",
+ "clap 3.0.0",
  "config",
  "dirs-next",
  "git2",
  "glob",
- "lazy_static",
- "serde 1.0.132",
+ "once_cell",
+ "serde 1.0.133",
  "shellexpand",
  "skim",
- "structopt",
 ]
 
 [[package]]
@@ -436,6 +468,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,6 +512,16 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -663,6 +711,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -706,18 +763,18 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.34"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f84e92c0f7c9d58328b85a78557813e4bd845130db68d7184635344399423b1"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
 dependencies = [
  "proc-macro2",
 ]
@@ -833,9 +890,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
+checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
 dependencies = [
  "serde_derive",
 ]
@@ -854,9 +911,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
+checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -865,13 +922,13 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.73"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbd0344bc6533bc7ec56df11d42fb70f1b912351c0825ccb7211b59d8af7cf5"
+checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
 dependencies = [
  "itoa",
  "ryu",
- "serde 1.0.132",
+ "serde 1.0.133",
 ]
 
 [[package]]
@@ -905,7 +962,7 @@ dependencies = [
  "beef",
  "bitflags",
  "chrono",
- "clap",
+ "clap 2.34.0",
  "crossbeam",
  "defer-drop",
  "derive_builder",
@@ -961,7 +1018,7 @@ checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "serde 1.0.132",
+ "serde 1.0.133",
  "serde_derive",
  "syn",
 ]
@@ -975,7 +1032,7 @@ dependencies = [
  "base-x",
  "proc-macro2",
  "quote",
- "serde 1.0.132",
+ "serde 1.0.133",
  "serde_derive",
  "serde_json",
  "sha1",
@@ -1001,34 +1058,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
-name = "structopt"
-version = "0.3.25"
+name = "strsim"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.83"
+version = "1.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a1dfb999630e338648c83e91c59a4e9fb7620f520c3194b6b89e276f2f1959"
+checksum = "ecb2e6da8ee5eb9a61068762a32fa9619cc591ceb055b3687f4cd4051ec2e06b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1055,11 +1094,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+dependencies = [
+ "terminal_size",
  "unicode-width",
 ]
 
@@ -1150,7 +1209,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
- "serde 1.0.132",
+ "serde 1.0.133",
 ]
 
 [[package]]
@@ -1165,6 +1224,15 @@ dependencies = [
  "nix 0.14.1",
  "term",
  "unicode-width",
+]
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]
@@ -1232,9 +1300,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "void"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ git2 = { version = "0.13", features = ["vendored-libgit2"], default-features = f
 config = { version = "0.11.0", features = ["yaml"] }
 serde = { version = "1.0", features = ["derive"] }
 ansi_term = "0.12"
-structopt = "0.3"
+clap = { version = "3.0.0", features = ["derive", "unicode", "wrap_help"] }
 skim = "0.9.4"
 dirs-next = "2.0.0"
 shellexpand = "2.1.0"
 glob = "0.3.0"
-lazy_static = "1.4.0"
+once_cell = "1.9.0"

--- a/src/commands/find.rs
+++ b/src/commands/find.rs
@@ -1,23 +1,22 @@
-use structopt::StructOpt;
-
 use crate::{
     dirs::{get_dirs, GetDirsError},
     finder::find,
     settings::Settings,
 };
+use clap::Args;
 
-#[derive(StructOpt)]
+#[derive(Debug, Args)]
 pub struct Cmd {}
 
 impl Cmd {
     pub fn run(&self) -> Result<Option<String>, GetDirsError> {
         let dirs = get_dirs()?;
         if dirs.is_empty() {
-            let search_dirs = Settings::get_readonly().search_dirs;
+            let search_dirs = Settings::global().search_dirs;
             let search_dirs_str = if search_dirs.is_empty() {
                 String::from("[Empty list]")
             } else {
-                Settings::get_readonly()
+                Settings::global()
                     .search_dirs
                     .iter()
                     .map(|dir_str| format!("- {}", dir_str))

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,12 +1,13 @@
-use structopt::StructOpt;
+use clap::Subcommand;
 
-#[derive(StructOpt)]
+#[derive(Debug, Subcommand)]
+#[clap(about = "Set up ctrl+g keybind for specified shell")]
 pub enum Cmd {
-    #[structopt(about = "Set up ctrl+g keybind for Fish shell")]
+    #[clap(about = "Set up ctrl+g keybind for Fish shell")]
     Fish,
-    #[structopt(about = "Set up ctrl+g keybind for Bash")]
+    #[clap(about = "Set up ctrl+g keybind for Bash")]
     Bash,
-    #[structopt(about = "Set up ctrl+g keybind for Zsh")]
+    #[clap(about = "Set up ctrl+g keybind for Zsh")]
     Zsh,
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,14 +1,15 @@
+use clap::{AppSettings, Subcommand};
 use std::error::Error;
-use structopt::StructOpt;
 
 pub mod find;
 pub mod init;
 
-#[derive(StructOpt)]
+#[derive(Debug, Subcommand)]
+#[clap(setting = AppSettings::DeriveDisplayOrder)]
 pub enum CtrlgCommand {
-    #[structopt(about = "Find a directory based on configured globbing patterns")]
+    #[clap(about = "Find a directory based on configured globbing patterns")]
     Find(find::Cmd),
-    #[structopt(about = "Set up ctrl+g keybind for specified shell")]
+    #[clap(subcommand)]
     Init(init::Cmd),
 }
 

--- a/src/dir_item.rs
+++ b/src/dir_item.rs
@@ -69,13 +69,13 @@ fn get_display(path: &Path) -> Result<String, DirItemError> {
         .unwrap()
         .to_string();
 
-    if !Settings::get_readonly().show_git_branch {
+    if !Settings::global().show_git_branch {
         return Ok(display);
     }
 
     let branch = git_meta::get_current_branch(path)?;
     if let Some(branch) = branch {
-        let settings = Settings::get_readonly();
+        let settings = Settings::global();
         let color_settings = settings.colors;
         display = format!(
             "{}  {} {}",
@@ -91,7 +91,7 @@ fn get_display(path: &Path) -> Result<String, DirItemError> {
 }
 
 fn get_readme(path: &Path) -> Result<Option<PathBuf>, io::Error> {
-    for glob_pattern in Settings::get_readonly().preview_files.iter() {
+    for glob_pattern in Settings::global().preview_files.iter() {
         let mut preview_file_pattern = path.to_path_buf();
         preview_file_pattern.push(glob_pattern);
 

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -36,7 +36,7 @@ impl Display for GetDirsError {
 
 pub fn get_dirs() -> Result<Vec<DirItem>, GetDirsError> {
     let mut items = Vec::new();
-    for dir in Settings::get_readonly().search_dirs.iter() {
+    for dir in Settings::global().search_dirs.iter() {
         let dir = shellexpand::tilde(dir);
         for child in glob(&dir).expect("Failed to resolve globbing pattern") {
             let path = child?;

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -15,7 +15,7 @@ impl SkimItem for DirItem {
     }
 
     fn preview(&self, _context: PreviewContext) -> ItemPreview {
-        let settings = Settings::get_readonly();
+        let settings = Settings::global();
         if self.readme.is_none() {
             if settings.preview_fallback_exa {
                 return ItemPreview::Command(format!(
@@ -64,7 +64,7 @@ fn receiver(items: &[DirItem]) -> SkimItemReceiver {
 pub fn find(items: &[DirItem]) -> Option<String> {
     let skim_options = SkimOptionsBuilder::default()
         .height(Some("100%"))
-        .preview(if Settings::get_readonly().preview {
+        .preview(if Settings::global().preview {
             Some("")
         } else {
             None

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,7 @@
-#[macro_use]
-extern crate lazy_static;
+use clap::{AppSettings, Parser};
 use commands::CtrlgCommand;
+use settings::Settings;
 use std::error::Error;
-use structopt::{clap::AppSettings, StructOpt};
 
 mod colors;
 mod command_strs;
@@ -15,19 +14,16 @@ mod settings;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-#[derive(StructOpt)]
-#[structopt(
+#[derive(Debug, Parser)]
+#[clap(
     author = "Mat Jones <mat@mjones.network>",
     version = VERSION,
     about = "Press ctrl+g to search and jump to any directory",
-    global_settings(&[
-        AppSettings::UnifiedHelpMessage,
-        AppSettings::ColoredHelp,
-        AppSettings::DeriveDisplayOrder
-    ])
+    global_setting = AppSettings::PropagateVersion,
+    global_setting = AppSettings::DeriveDisplayOrder,
 )]
 struct Ctrlg {
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     ctrlg: CtrlgCommand,
 }
 
@@ -38,6 +34,7 @@ impl Ctrlg {
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
-    Ctrlg::from_args().run()?;
+    Settings::init()?;
+    Ctrlg::parse().run()?;
     Ok(())
 }


### PR DESCRIPTION
Fixes #28 

Also replaces `lazy_static` with `once_cell` since `lazy_static` is now unmaintained.