### PR TITLE
add ctrl+d and ctrl+f keybinds for scrolling previews up and down, respectively

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,10 @@ export CTRLG_TMUX=true
 | ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | <kbd>Enter</kbd>                         | `cd` to the selected directory.                                                                                                                                            |
 | <kbd>Alt/Option</kbd> + <kbd>Enter</kbd> | `cd` to the selected directory, then open `$EDITOR` if defined. The `$EDITOR` command is only run in the currently active `tmux` pane, if using the `tmux` integration.    |
-| <kbd>Ctrl</kbd> + <kbd>o</kbd>           | `cd` to selected directory *only in current `tmux` pane*, do not send `cd` command to other `tmux` panes.                                                                  |
+| <kbd>Ctrl</kbd> + <kbd>o</kbd>           | `cd` to selected directory _only in current `tmux` pane_, do not send `cd` command to other `tmux` panes.                                                                  |
 | <kbd>Tab</kbd>                           | Insert the selected directory path to the command line, but do not execute anything. Works in Fish and zsh only, in bash, acts the same as <kbd>Ctrl</kbd> + <kbd>o</kbd>. |
+| <kbd>Ctrl</kbd> + <kbd>d</kbd>           | Scroll preview up.                                                                                                                                                         |
+| <kbd>Ctrl</kbd> + <kbd>f</kbd>           | Scroll preview down.                                                                                                                                                       |
 
 ## Configuration
 

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -69,7 +69,13 @@ pub fn find(items: &[DirItem]) -> Option<String> {
         } else {
             None
         })
-        .bind(vec!["alt-enter:accept", "ctrl-o:accept", "tab:accept"])
+        .bind(vec![
+            "alt-enter:accept",
+            "ctrl-o:accept",
+            "tab:accept",
+            "ctrl-d:preview-up",
+            "ctrl-f:preview-down",
+        ])
         .multi(false)
         .build()
         .unwrap();


### PR DESCRIPTION
Fixes: #49 