### PR TITLE
add keybind to `pushd selected/dir && $EDITOR && popd` in current tmux pane only

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ export CTRLG_TMUX_POPUP_ARGS="-w 75% -h 75%"
 | ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | <kbd>Enter</kbd>                         | `cd` to the selected directory. If `$CTRLG_TMUX` is `true`, the `cd` command is sent to all split panes in the current window.                                             |
 | <kbd>Alt/Option</kbd> + <kbd>Enter</kbd> | `cd` to the selected directory, then open `$EDITOR` if defined. The `$EDITOR` command is only run in the currently active `tmux` pane, if using the `tmux` integration.    |
+| <kbd>Alt/Option</kbd> + <kbd>o</kbd>     | Open `$EDITOR` to selected directory without `cd`ing the shell.                                                                                                            |
 | <kbd>Ctrl</kbd> + <kbd>o</kbd>           | `cd` to selected directory _only in current `tmux` pane_, do not send `cd` command to other `tmux` panes.                                                                  |
 | <kbd>Tab</kbd>                           | Insert the selected directory path to the command line, but do not execute anything. Works in Fish and zsh only, in bash, acts the same as <kbd>Ctrl</kbd> + <kbd>o</kbd>. |
 | <kbd>Ctrl</kbd> + <kbd>d</kbd>           | Scroll preview up.                                                                                                                                                         |

--- a/src/commands/shell/ctrlg.bash
+++ b/src/commands/shell/ctrlg.bash
@@ -4,7 +4,7 @@
 # having to toggle on and off the
 # synchronize-panes option manually
 function _ctrlg_tmux_send_all_panes {
-  if test -z "$TMUX"; then
+  if test -z "$TMUX" || test -z "$CTRLG_TMUX"; then
     eval "$1"
   else
     local current_pane
@@ -40,20 +40,31 @@ function _ctrlg_search_and_go {
   ctrlg_selected_dir=${ctrlg_output/"ctrlg_edit:"/}
   ctrlg_selected_dir=${ctrlg_selected_dir/"ctrlg_notmux:"/}
   ctrlg_selected_dir=${ctrlg_selected_dir/"ctrlg_insert:"/}
-  if test -n "$ctrlg_selected_dir"; then
-    if [ "$CTRLG_TMUX" = "true" ] && [[ "$ctrlg_output" != ctrlg_notmux:* ]] && [[ "$ctrlg_output" != ctrlg_insert:* ]]; then
-      _ctrlg_tmux_send_all_panes "cd $ctrlg_selected_dir && clear"
-    else
-      cd "$ctrlg_selected_dir" || exit
-      clear
-    fi
+  ctrlg_selected_dir=${ctrlg_selected_dir/"ctrlg_pushd:"/}
 
-    if [[ "$ctrlg_output" = ctrlg_edit:* ]] && [[ "$EDITOR" != "" ]]; then
+  if test -z "$ctrlg_selected_dir"; then
+    return
+  fi
+
+  if [[ "$ctrlg_output" = ctrlg_insert:* ]]; then
+    cd "$ctrlg_selected_dir"
+  elif [[ "$ctrlg_output" = ctrlg_pushd:* ]]; then
+    if test -z "$EDITOR"; then
+      echo "\$EDITOR is not defined."
+      return
+    fi
+    pushd "$ctrlg_selected_dir" && $EDITOR && popd
+  elif [[ "$ctrlg_output" = ctrlg_notmux:* ]]; then
+    cd "$ctrlg_selected_dir"
+  else
+    _ctrlg_tmux_send_all_panes "cd $ctrlg_selected_dir && clear"
+    if [[ "$ctrlg_output" = ctrlg_edit:* ]]; then
+      if test -z "$EDITOR"; then
+        echo "\$EDITOR is not defined."
+        return
+      fi
       $EDITOR
     fi
-  else
-    READLINE_LINE=${ctrlg_selected_dir}
-    READLINE_POINT=${#READLINE_LINE}
   fi
 }
 

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -71,6 +71,7 @@ pub fn find(items: &[DirItem]) -> Option<String> {
         })
         .bind(vec![
             "alt-enter:accept",
+            "alt-o:accept",
             "ctrl-o:accept",
             "tab:accept",
             "ctrl-d:preview-up",
@@ -103,6 +104,7 @@ pub fn find(items: &[DirItem]) -> Option<String> {
                     Key::Enter => Some(path),
                     Key::AltEnter => Some(format!("ctrlg_edit:{}", path)),
                     Key::Ctrl('o') => Some(format!("ctrlg_notmux:{}", path)),
+                    Key::Alt('o') => Some(format!("ctrlg_pushd:{}", path)),
                     Key::Tab => Some(format!("ctrlg_insert:{}", path)),
                     _ => None,
                 };


### PR DESCRIPTION
Fixes: #59 

Also cleans up the way the shell plugins are written, it should make it easier to reason about and add additional key binds going forward.